### PR TITLE
make ribbon smoother in Firefox

### DIFF
--- a/src/ribbonStyle.js
+++ b/src/ribbonStyle.js
@@ -54,7 +54,7 @@ export const RibbonStyle = {
 
     /* Add "stitching" effect */
     borderWidth: '1px 0',
-    borderStyle: 'dotted',
+    borderStyle: 'dashed',
     // borderColor: '#fff',
     borderColor: 'rgba(255, 255, 255, 0.7)'
   },


### PR DESCRIPTION
Chrome, dotted:
![default](https://user-images.githubusercontent.com/6039544/34323660-ee3147b2-e864-11e7-9dc6-866e703ecfef.png)
Chrome, dashed:
![default](https://user-images.githubusercontent.com/6039544/34323664-0870cf26-e865-11e7-8c4c-3fc3d2a63fd8.png)
Firefox, dotted:
![default](https://user-images.githubusercontent.com/6039544/34323667-44900008-e865-11e7-9ac1-8f26cc1b9fca.png)
Firefox, dashed:
![default](https://user-images.githubusercontent.com/6039544/34323669-5740b472-e865-11e7-8789-93035e017b50.png)
As you can see, dots of this ribbon looks lousy. So If I change css rule from 'dotted' to 'dashed' It will look better, don't It?