### PR TITLE
add rel=noopener to link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,8 @@ const GitHubForkRibbon = ({position = 'right', href, target, color = 'red', clas
            style={ribbonStyle}>
         <a href={href}
            target={target}
-           style={RibbonStyle.urlStyle}>
+           style={RibbonStyle.urlStyle}
+           rel="noopener">
           {children}
         </a>
       </div>

--- a/storybook/__tests__/__snapshots__/GithubForkRibbon.stories.js.snap
+++ b/storybook/__tests__/__snapshots__/GithubForkRibbon.stories.js.snap
@@ -42,6 +42,7 @@ exports[`default with right position and red color 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -107,6 +108,7 @@ exports[`handle unexist color with default 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -172,6 +174,7 @@ exports[`handle unexist position with default 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -258,6 +261,7 @@ exports[`on left position 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -324,6 +328,7 @@ exports[`on left-bottom position 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -389,6 +394,7 @@ exports[`on right position 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -455,6 +461,7 @@ exports[`on right-bottom position 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -520,6 +527,7 @@ exports[`with black color 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -585,6 +593,7 @@ exports[`with green color 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -650,6 +659,7 @@ exports[`with orange color 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
@@ -715,6 +725,7 @@ exports[`with red color 1`] = `
   >
     <a
       href="//www.google.com"
+      rel="noopener"
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",

--- a/storybook/__tests__/__snapshots__/GithubForkRibbon.stories.js.snap
+++ b/storybook/__tests__/__snapshots__/GithubForkRibbon.stories.js.snap
@@ -2,7 +2,7 @@
 
 exports[`default with right position and red color 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -45,7 +45,7 @@ exports[`default with right position and red color 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -67,7 +67,7 @@ exports[`default with right position and red color 1`] = `
 
 exports[`handle unexist color with default 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -110,7 +110,7 @@ exports[`handle unexist color with default 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -132,7 +132,7 @@ exports[`handle unexist color with default 1`] = `
 
 exports[`handle unexist position with default 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -175,7 +175,7 @@ exports[`handle unexist position with default 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -195,9 +195,30 @@ exports[`handle unexist position with default 1`] = `
 </div>
 `;
 
+exports[`hidden on small devices up to 576px 1`] = `
+<div>
+  <style>
+    
+          @media (max-width: 576px) {
+            .custom-class {
+              display: none;
+            }
+          }
+        
+  </style>
+  <GitHubForkRibbon
+    className="custom-class"
+    href="//www.google.com"
+    target="_blank"
+  >
+    Fork me on GitHub
+  </GitHubForkRibbon>
+</div>
+`;
+
 exports[`on left position 1`] = `
 <div
-  className="github-fork-ribbon-wrapper left"
+  className="github-fork-ribbon-wrapper left "
   style={
     Object {
       "height": "150px",
@@ -240,7 +261,7 @@ exports[`on left position 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -262,7 +283,7 @@ exports[`on left position 1`] = `
 
 exports[`on left-bottom position 1`] = `
 <div
-  className="github-fork-ribbon-wrapper left-bottom"
+  className="github-fork-ribbon-wrapper left-bottom "
   style={
     Object {
       "bottom": 0,
@@ -306,7 +327,7 @@ exports[`on left-bottom position 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -328,7 +349,7 @@ exports[`on left-bottom position 1`] = `
 
 exports[`on right position 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -371,7 +392,7 @@ exports[`on right position 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -393,7 +414,7 @@ exports[`on right position 1`] = `
 
 exports[`on right-bottom position 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right-bottom"
+  className="github-fork-ribbon-wrapper right-bottom "
   style={
     Object {
       "bottom": 0,
@@ -437,7 +458,7 @@ exports[`on right-bottom position 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -459,7 +480,7 @@ exports[`on right-bottom position 1`] = `
 
 exports[`with black color 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -502,7 +523,7 @@ exports[`with black color 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -524,7 +545,7 @@ exports[`with black color 1`] = `
 
 exports[`with green color 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -567,7 +588,7 @@ exports[`with green color 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -589,7 +610,7 @@ exports[`with green color 1`] = `
 
 exports[`with orange color 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -632,7 +653,7 @@ exports[`with orange color 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",
@@ -654,7 +675,7 @@ exports[`with orange color 1`] = `
 
 exports[`with red color 1`] = `
 <div
-  className="github-fork-ribbon-wrapper right"
+  className="github-fork-ribbon-wrapper right "
   style={
     Object {
       "height": "150px",
@@ -697,7 +718,7 @@ exports[`with red color 1`] = `
       style={
         Object {
           "borderColor": "rgba(255, 255, 255, 0.7)",
-          "borderStyle": "dotted",
+          "borderStyle": "dashed",
           "borderWidth": "1px 0",
           "color": "#fff",
           "display": "inline-block",


### PR DESCRIPTION
Add `noopener` to the anchor to avoid security warning in lighthouse report.

Changes:
1. fix snapshot tests
2. add `rel="noopener"` to the link

https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
